### PR TITLE
correctly handle requirements with square brackets

### DIFF
--- a/libyear/utils.py
+++ b/libyear/utils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import typer
 
-REQUIREMENT_NAME_RE = r"^([^=><]+)"
+REQUIREMENT_NAME_RE = r"^([^\[=><]+)"
 REQUIREMENT_VERSION_LT_RE = r"<([^$,]*)"
 REQUIREMENT_VERSION_LTE_RE = r"[<=]=([^$,]*)"
 

--- a/tests/data/requirements.txt
+++ b/tests/data/requirements.txt
@@ -142,6 +142,9 @@ pluggy==0.13.1 \
 pre-commit==1.20.0 \
     --hash=sha256:9f152687127ec90642a2cc3e4d9e1e6240c4eb153615cb02aa1ad41d331cbb6e \
     --hash=sha256:c2e4810d2d3102d354947907514a78c5d30424d299dc0fe48f5aa049826e9b50
+psycopg[binary,pool]==3.2.9 \
+    --hash=sha256:01a8dadccdaac2123c916208c96e06631641c0566b22005493f09663c7a8d3b6 \
+    --hash=sha256:2fbb46fcd17bc81f993f28c47f1ebea38d66ae97cc2dbc3cad73b37cefbff700
 py==1.8.0 \
     --hash=sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa \
     --hash=sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53 \

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ def test_gets_name_and_version_from_requirements_file_with_hashes():
     }
 
     assert ("appdirs", "1.4.3", None) in results
+    assert ("psycopg", "3.2.9", None) in results
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See #16. When encountering a requirement like `psycopg[binary,pool]==3.2.9` or `python-jose[cryptography]==3.4.0` it was treating the entire left half as the package name to look up in PyPI, which would then fail and it would just ignore that one, missing any potential updates. This tightens up the name matching so it would find `psycopg` or `python-jose` respectively and be able to look up the correct package in PyPI. Ideally, it would maintain the full name string with the optional dependencies and check those as well. For now, this is a quick improvement that at least makes it work correctly for the base package.