### PR TITLE
fix: Include `typing_extensions`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "prettytable>=3.10.0",
     "python-dateutil>=2.9.0.post0",
     "typer>=0.12.3",
+    "typing-extensions>=4.15.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #18

I picked the current version of typing_extensions (released Aug 2025). If you want to relax that at all, let me know.